### PR TITLE
ブラウザサイズ変更時とキャンバス拡大時に、レイアウトが段落ちしないように調整

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "editor.formatOnSave": false,
     "editor.codeActionsOnSave": {
 
         "source.fixAll.eslint": true

--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ yarn lint
 - [TypeScript Deep Dive](https://basarat.gitbook.io/typescript/)
 - [Vue.js official style guide](https://v2.vuejs.org/v2/style-guide/index.html)
 
+## Coding Rules
+### SCSS
+- As a general rule, use the styles built into Vuetify, and write SCSS in /src/styles/* **only when necessary**.
+- All class names must be prefixed with "c" (the abbreviation of "customized") to clarify it's not the styles built into Vuetify.
+- Use BEM(https://en.bem.info/methodology/css/) as the naming convention.
+- For example:
+```html
+<div class="c__main">
+  <h2 class="c__main__title">This is a title</h2>
+</div>
+```
+
 ## Contributing
 1. Fork it (`git clone https://github.com/t29mato/starry-digitizer.git`)
 2. Create your feature branch (`git checkout -b your-new-feature`)

--- a/src/components/Canvas/CanvasMain.vue
+++ b/src/components/Canvas/CanvasMain.vue
@@ -6,7 +6,7 @@
       'user-drag': 'none',
       outline: 'solid 1px grey',
       overflow: 'auto',
-      'max-height': '87vh',
+      'max-height': '80vh',
     }"
     id="canvasWrapper"
     @click="plot"

--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container fluid>
-    <v-row>
-      <v-col class="pr-0 pt-1 pl-1" style="max-width: 240px">
+    <div class="wrapper">
+      <div class="sidebar_left">
         <image-settings></image-settings>
         <axes-settings></axes-settings>
         <dataset-manager
@@ -9,21 +9,21 @@
           :exportBtnClick="exportBtnClick"
         ></dataset-manager>
         <data-table />
-      </v-col>
-      <v-col class="pt-1 pl-2 pr-0">
+      </div>
+      <div class="main-area">
         <canvas-header></canvas-header>
         <canvas-main :imagePath="initialGraphImagePath"></canvas-main>
         <canvas-footer></canvas-footer>
-      </v-col>
-      <v-col class="pt-1 pr-1" style="max-width: 300px">
+      </div>
+      <div class="sidebar_right">
         <!-- TODO: 有効数字を追加する -->
         <magnifier-main></magnifier-main>
         <extractor-settings
           :initialExtractorStrategy="initialExtractorStrategy"
         ></extractor-settings>
         <p class="text-caption text-right">v{{ version }}</p>
-      </v-col>
-    </v-row>
+      </div>
+    </div>
   </v-container>
 </template>
 
@@ -74,3 +74,22 @@ export default Vue.extend({
   },
 })
 </script>
+
+<style lang="scss" scoped>
+$_sidebarWidth: 300px;
+.wrapper {
+  display: flex;
+}
+
+.sidebar {
+  &_left,
+  &_right {
+    width: $_sidebarWidth;
+  }
+}
+
+.main-area {
+  margin: 0 20px;
+  width: calc(100% - #{$_sidebarWidth} * 2);
+}
+</style>

--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -76,20 +76,24 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
-$_sidebarWidth: 300px;
+$_sidebarLeftWidth: 240px;
+$_sidebarRightWidth: 300px;
 .wrapper {
   display: flex;
 }
 
 .sidebar {
-  &_left,
+  &_left {
+    width: $_sidebarLeftWidth;
+  }
+
   &_right {
-    width: $_sidebarWidth;
+    width: $_sidebarRightWidth;
   }
 }
 
 .main-area {
   margin: 0 20px;
-  width: calc(100% - #{$_sidebarWidth} * 2);
+  width: calc(100% - (#{$_sidebarLeftWidth} + #{$_sidebarRightWidth}));
 }
 </style>

--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -74,26 +74,3 @@ export default Vue.extend({
   },
 })
 </script>
-
-<style lang="scss" scoped>
-$_sidebarLeftWidth: 240px;
-$_sidebarRightWidth: 300px;
-.wrapper {
-  display: flex;
-}
-
-.sidebar {
-  &_left {
-    width: $_sidebarLeftWidth;
-  }
-
-  &_right {
-    width: $_sidebarRightWidth;
-  }
-}
-
-.main-area {
-  margin: 0 20px;
-  width: calc(100% - (#{$_sidebarLeftWidth} + #{$_sidebarRightWidth}));
-}
-</style>

--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container fluid>
-    <div class="wrapper">
-      <div class="sidebar_left">
+    <div class="c__wrapper">
+      <div class="c__left-sidebar">
         <image-settings></image-settings>
         <axes-settings></axes-settings>
         <dataset-manager
@@ -10,12 +10,12 @@
         ></dataset-manager>
         <data-table />
       </div>
-      <div class="main-area">
+      <div class="c__main-area">
         <canvas-header></canvas-header>
         <canvas-main :imagePath="initialGraphImagePath"></canvas-main>
         <canvas-footer></canvas-footer>
       </div>
-      <div class="sidebar_right">
+      <div class="c__right-sidebar">
         <!-- TODO: 有効数字を追加する -->
         <magnifier-main></magnifier-main>
         <extractor-settings

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,8 @@ import Vue from 'vue'
 import App from './App.vue'
 import vuetify from './plugins/vuetify'
 
+require('./styles/style.scss')
+
 Vue.config.productionTip = false
 
 new Vue({

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -1,0 +1,22 @@
+//vuetifyで実現できないスタイルのみ書く。必要最低限で
+
+@import './variables/main.scss';
+
+.wrapper {
+  display: flex;
+}
+
+.sidebar {
+  &_left {
+    width: $_sidebarLeftWidth;
+  }
+
+  &_right {
+    width: $_sidebarRightWidth;
+  }
+}
+
+.main-area {
+  margin: 0 20px;
+  width: calc(100% - (#{$_sidebarLeftWidth} + #{$_sidebarRightWidth}));
+}

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -6,22 +6,23 @@
   box-sizing: border-box;
 }
 
-.wrapper {
-  display: flex;
-}
-
-.sidebar {
-  &_left {
-    width: $_sidebarLeftWidth;
+//c is the abbreviation of 'customized'
+.c {
+  &__wrapper {
+    display: flex;
   }
 
-  &_right {
-    width: $_sidebarRightWidth;
+  &__left-sidebar {
+    width: $l_leftSidebarWidth;
+  }
+
+  &__right-sidebar {
+    width: $l_rightSidebarWidth;
+  }
+
+  &__main-area {
+    margin: 0 $l_mainAreaSideMargin;
+    width: calc(100% - (#{$l_leftSidebarWidth} + #{$l_rightSidebarWidth} + (#{$l_mainAreaSideMargin * 2})));
   }
 }
 
-$_mainAreaSideMargin: 20px;
-.main-area {
-  margin: 0 $_mainAreaSideMargin;
-  width: calc(100% - (#{$_sidebarLeftWidth} + #{$_sidebarRightWidth} + (#{$_mainAreaSideMargin * 2})));
-}

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -2,6 +2,10 @@
 
 @import './variables/main.scss';
 
+* {
+  box-sizing: border-box;
+}
+
 .wrapper {
   display: flex;
 }
@@ -16,7 +20,8 @@
   }
 }
 
+$_mainAreaSideMargin: 20px;
 .main-area {
-  margin: 0 20px;
-  width: calc(100% - (#{$_sidebarLeftWidth} + #{$_sidebarRightWidth}));
+  margin: 0 $_mainAreaSideMargin;
+  width: calc(100% - (#{$_sidebarLeftWidth} + #{$_sidebarRightWidth} + (#{$_mainAreaSideMargin * 2})));
 }

--- a/src/styles/variables/layout.scss
+++ b/src/styles/variables/layout.scss
@@ -1,0 +1,2 @@
+$_sidebarLeftWidth: 240px;
+$_sidebarRightWidth: 300px;

--- a/src/styles/variables/layout.scss
+++ b/src/styles/variables/layout.scss
@@ -1,2 +1,3 @@
-$_sidebarLeftWidth: 240px;
-$_sidebarRightWidth: 300px;
+$l_leftSidebarWidth: 240px;
+$l_rightSidebarWidth: 300px;
+$l_mainAreaSideMargin: 20px;

--- a/src/styles/variables/main.scss
+++ b/src/styles/variables/main.scss
@@ -1,0 +1,1 @@
+@import './layout.scss';


### PR DESCRIPTION
https://github.com/starrydata/starrydata2/issues/110
・SCSSファイルを追加しアプリケーションに適用
・左右サイドバーの幅を300pxに固定したまま、メインキャンバスエリアの幅を可変に修正