### PR TITLE
fix: In the definition mode with 4 points of XY axis, when the tilt i…

### DIFF
--- a/src/domains/XYAxesCalculator.test.ts
+++ b/src/domains/XYAxesCalculator.test.ts
@@ -77,15 +77,91 @@ describe('XYAxesCalculator', () => {
     expect(result.yV).toBe('5.5e+0')
   })
 
-  it('should calculate XY values correctly with graph tilt', () => {
-    axesMock.considerGraphTilt = true
-    axesMock.x1.coord = { xPx: 0, yPx: 500 }
-    axesMock.x2.coord = { xPx: 1000, yPx: 600 }
-    axesMock.y1.coord = { xPx: 500, yPx: 1000 }
-    axesMock.y2.coord = { xPx: 600, yPx: 0 }
+  // INFO: fix the following issue https://github.com/t29mato/starry-digitizer/issues/17
+  it('should calculate XY values correctly without graph tilt from Saito-san case', () => {
+    const plot = { id: 1, xPx: 436.3524590163934, yPx: 192.08879781420765 }
+    axesMock = {
+      // @ts-ignore
+      x1: {
+        name: 'x1',
+        value: 100,
+        coord: { xPx: 244.72677595628414, yPx: 353.23770491803276 },
+        initialCoord: { xPx: -999, yPx: -999 },
+      },
+      // @ts-ignore
+      x2: {
+        name: 'x2',
+        value: 300,
+        coord: { xPx: 629.1325136612022, yPx: 355.5464480874317 },
+        initialCoord: { xPx: -999, yPx: -999 },
+      },
+      // @ts-ignore
+      y1: {
+        name: 'y1',
+        value: 20,
+        coord: { xPx: 245.88114754098362, yPx: 197.39754098360655 },
+        initialCoord: { xPx: -999, yPx: -999 },
+      },
+      // @ts-ignore
+      y2: {
+        name: 'y2',
+        value: 30,
+        coord: { xPx: 243.5724043715847, yPx: 45.02049180327869 },
+        initialCoord: { xPx: -999, yPx: -999 },
+      },
+      xIsLog: false,
+      yIsLog: false,
+      activeAxisName: '',
+      x1IsSameAsY1: false,
+      considerGraphTilt: false,
+      isAdjusting: false,
+    }
     const calculator = new XYAxesCalculator(axesMock, { x: false, y: false })
-    const result = calculator.calculateXYValues(550, 550)
-    expect(result.xV).toBe('5.9455e+0')
-    expect(result.yV).toBe('1.0446e+0')
+    const result = calculator.calculateXYValues(plot.xPx, plot.yPx)
+    expect(result).toStrictEqual({ xV: '1.997e+2', yV: '2.035e+1' })
+  })
+
+  // INFO: fix the following issue https://github.com/t29mato/starry-digitizer/issues/17
+  it('should calculate XY values correctly with graph tilt from Saito-san case', () => {
+    const plot = { id: 1, xPx: 436.3524590163934, yPx: 192.08879781420765 }
+    axesMock = {
+      // @ts-ignore
+      x1: {
+        name: 'x1',
+        value: 100,
+        coord: { xPx: 244.72677595628414, yPx: 353.23770491803276 },
+        initialCoord: { xPx: -999, yPx: -999 },
+      },
+      // @ts-ignore
+      x2: {
+        name: 'x2',
+        value: 300,
+        coord: { xPx: 629.1325136612022, yPx: 355.5464480874317 },
+        initialCoord: { xPx: -999, yPx: -999 },
+      },
+      // @ts-ignore
+      y1: {
+        name: 'y1',
+        value: 20,
+        coord: { xPx: 245.88114754098362, yPx: 197.39754098360655 },
+        initialCoord: { xPx: -999, yPx: -999 },
+      },
+      // @ts-ignore
+      y2: {
+        name: 'y2',
+        value: 30,
+        coord: { xPx: 243.5724043715847, yPx: 45.02049180327869 },
+        initialCoord: { xPx: -999, yPx: -999 },
+      },
+      xIsLog: false,
+      yIsLog: false,
+      activeAxisName: '',
+      x1IsSameAsY1: false,
+      considerGraphTilt: true, // This is the difference of this test case
+      isAdjusting: false,
+    }
+    const calculator = new XYAxesCalculator(axesMock, { x: false, y: false })
+    const result = calculator.calculateXYValues(plot.xPx, plot.yPx)
+    expect(result).toStrictEqual({ xV: '2.01e+2', yV: '2.042e+1' })
   })
 })

--- a/src/domains/XYAxesCalculator.ts
+++ b/src/domains/XYAxesCalculator.ts
@@ -50,7 +50,7 @@ export default class XYAxesCalculator {
       const xcd = xd - xc
       const ycd = yd - yc
       const r = ((yt - ya) * xcd - (xt - xa) * ycd) / (yab * xcd - xab * ycd)
-      const s = ((yt - ya) * xab - (xt - xa) * yab) / (ycd * xab - xcd * yab)
+      const s = ((yt - yc) * xab - (xt - xc) * yab) / (ycd * xab - xcd * yab)
       xp = xa + r * xab
       yq = yc + s * ycd
     }


### PR DESCRIPTION
…s set to ON, the values are incorrect when X1 and Y1 are different coordinates. issue #17