### PR TITLE
補完する点群の総距離が短すぎる場合にsegmentsが0になりエラーとなるので、segmentsの最小値を1に

### DIFF
--- a/src/domains/interpolator.ts
+++ b/src/domains/interpolator.ts
@@ -16,9 +16,14 @@ export class Interpolator implements InterpolatorInterface {
 
     const interp = new CurveInterpolator(points, { tension: 0.2, alpha: 0.5 })
 
-    const segments = Math.floor(
-      this.getPlotsTotalDistance(plots) / (this.interval * 1.6), //INFO: intervalが10の時、点同士の間隔がおよそ16pxになるようにした比例式
+    const segments = Math.max(
+      Math.floor(
+        this.getPlotsTotalDistance(plots) / (this.interval * 1.6), //INFO: intervalが10の時、点同士の間隔がおよそ16pxになるようにした比例式
+      ),
+      1,
     )
+
+    console.log(segments)
 
     this.interpolatedCoords = interp
       .getPoints(segments)


### PR DESCRIPTION
https://github.com/t29mato/starry-digitizer/pull/47#issuecomment-1823817073

上記の単体テストエラーの原因となる箇所の修正です。
対応内容はタイトルの通り