### PR TITLE
Auto Extractで抽出した点が非表示になってしまう不具合の解消

### DIFF
--- a/cypress/e2e/spec.extract-selection-area.cy.ts
+++ b/cypress/e2e/spec.extract-selection-area.cy.ts
@@ -21,5 +21,7 @@ describe('template spec', () => {
     cy.scrollTo(0, 0)
     cy.contains('Run').click()
     cy.scrollTo(0, 0)
+
+    cy.get('.dataset-count-1 > span').should('have.text', 21)
   })
 })

--- a/src/components/Settings/ExtractorSettings.vue
+++ b/src/components/Settings/ExtractorSettings.vue
@@ -147,7 +147,6 @@ export default defineComponent({
     async extractPlots() {
       this.isExtracting = true
       this.inactivateAxis()
-      this.clearPlots()
       try {
         this.setPlots(this.extractor.execute(this.canvas))
         this.sortPlots()

--- a/src/domains/datasets.test.ts
+++ b/src/domains/datasets.test.ts
@@ -23,3 +23,16 @@ test('pop a dataset', () => {
   datasets.popDataset()
   expect(datasets.datasets[datasets.datasets.length - 1].id).toBe(3)
 })
+
+test('set plots', () => {
+  const datasets = new Datasets(new Dataset('dataset 1', [], 1))
+  datasets.addDataset(new Dataset('dataset 2', [], datasets.nextDatasetId))
+  datasets.setPlots([{ xPx: 1, yPx: 1 }])
+  expect(datasets.activeDataset.plots).toStrictEqual([
+    { id: 1, xPx: 1, yPx: 1 },
+  ])
+  datasets.setPlots([{ xPx: 2, yPx: 2 }])
+  expect(datasets.activeDataset.plots).toStrictEqual([
+    { id: 1, xPx: 2, yPx: 2 },
+  ])
+})

--- a/src/domains/datasets.ts
+++ b/src/domains/datasets.ts
@@ -1,4 +1,4 @@
-import { DatasetInterface, Plots, Coord } from './datasetInterface'
+import { DatasetInterface, Coord } from './datasetInterface'
 
 export class Datasets {
   datasets: DatasetInterface[]
@@ -29,8 +29,10 @@ export class Datasets {
     return this.datasets[this.datasets.length - 1].id + 1
   }
 
-  setPlots(plots: Plots) {
-    this.activeDataset.plots = plots
+  setPlots(coords: Coord[]) {
+    coords.forEach((coord) => {
+      this.activeDataset.addPlot(coord.xPx, coord.yPx)
+    })
   }
 
   sortPlots() {

--- a/src/domains/datasets.ts
+++ b/src/domains/datasets.ts
@@ -30,6 +30,7 @@ export class Datasets {
   }
 
   setPlots(coords: Coord[]) {
+    this.activeDataset.clearPlots()
     coords.forEach((coord) => {
       this.activeDataset.addPlot(coord.xPx, coord.yPx)
     })

--- a/src/domains/extractStrategies/extractStrategyInterface.ts
+++ b/src/domains/extractStrategies/extractStrategyInterface.ts
@@ -1,4 +1,4 @@
-import { Plot } from '../datasetInterface'
+import { Coord } from '../datasetInterface'
 
 // INFO: Strategy Pattern
 export default interface ExtractStrategyInterface {
@@ -11,5 +11,5 @@ export default interface ExtractStrategyInterface {
     isDrawnMask: boolean,
     targetColor: [number, number, number],
     colorMatchThreshold: number,
-  ): Plot[]
+  ): Coord[]
 }

--- a/src/domains/extractStrategies/lineExtract.test.js
+++ b/src/domains/extractStrategies/lineExtract.test.js
@@ -12,7 +12,7 @@ wwwwww
 rrrrrr
 wwwwww
 `, () => {
-    const plots = extractor.execute(6, 6, [
+    const coords = extractor.execute(6, 6, [
         0, 0, 0, 0,
         0, 0, 0, 0,
         0, 0, 0, 0,
@@ -32,18 +32,15 @@ wwwwww
         0, 0, 0, 0,
         0, 0, 0, 0,
     ], [], false, [255, 0, 0], 10)
-    expect(plots).toEqual([{
-            "id": 0,
+    expect(coords).toEqual([{
             "xPx": 1,
             "yPx": 1.5,
         },
         {
-            "id": 1,
             "xPx": 3,
             "yPx": 1.5,
         },
         {
-            "id": 2,
             "xPx": 5,
             "yPx": 1.5,
         },

--- a/src/domains/extractStrategies/lineExtract.ts
+++ b/src/domains/extractStrategies/lineExtract.ts
@@ -1,6 +1,6 @@
 import ExtractStrategyInterface from './extractStrategyInterface'
 import { ExtractParent } from './extractParent'
-import { Plot } from '../datasetInterface'
+import { Coord } from '../datasetInterface'
 
 export default class LineExtract
   extends ExtractParent
@@ -30,7 +30,7 @@ export default class LineExtract
     targetColor: [number, number, number],
     colorMatchThreshold: number,
   ) {
-    const plots = []
+    const coords: Coord[] = []
     const visitedArea: boolean[][] = [...Array(height)].map(() =>
       Array(width).fill(false),
     )
@@ -74,9 +74,8 @@ export default class LineExtract
         )
         visitedArea[h][w] = true
         if (isMatch) {
-          const pixels: Plot[] = [
+          const pixels: Coord[] = [
             {
-              id: 0,
               xPx: w,
               yPx: h,
             },
@@ -115,7 +114,6 @@ export default class LineExtract
                   this.matchColor([r, g, b], targetColor, colorMatchThreshold)
                 ) {
                   pixels.push({
-                    id: pixels.length,
                     xPx: nw,
                     yPx: nh,
                   })
@@ -135,14 +133,13 @@ export default class LineExtract
           // INFO: In manual, pixels are limited to moving one pixel at a time.
           const offsetPx = 0.5
           // TODO: ここで桁数を指定する必要ない。表示時のみ対応でOK。
-          plots.push({
-            id: plots.length,
+          coords.push({
             xPx: parseFloat((xPxTotal / pixels.length + offsetPx).toFixed(1)),
             yPx: parseFloat((yPxTotal / pixels.length + offsetPx).toFixed(1)),
           })
         }
       }
     }
-    return plots
+    return coords
   }
 }

--- a/src/domains/extractStrategies/symbolExtractByArea.test.js
+++ b/src/domains/extractStrategies/symbolExtractByArea.test.js
@@ -17,7 +17,7 @@ rww
 www
 wwr
 `, () => {
-  const plots = extractor.execute(3,3,[
+  const coords = extractor.execute(3,3,[
     255,0,0,0,
     0,0,0,0,
     0,0,0,0,
@@ -28,14 +28,12 @@ wwr
     0,0,0,0,
     255,0,0,0,
   ], [], false, [255,0,0], 10)
-  expect(plots).toEqual([
+  expect(coords).toEqual([
     {
-      id: 0,
       xPx: 0.5,
       yPx: 0.5,
     },
     {
-      id: 1,
       xPx: 2.5,
       yPx: 2.5,
     },
@@ -47,7 +45,7 @@ rww
 wrw
 wwr
 `, () => {
-  const plots = extractor.execute(3,3,[
+  const coords = extractor.execute(3,3,[
     255,0,0,0,
     0,0,0,0,
     0,0,0,0,
@@ -58,9 +56,8 @@ wwr
     0,0,0,0,
     255,0,0,0,
   ], [], false, [255,0,0], 10)
-  expect(plots).toEqual([
+  expect(coords).toEqual([
     {
-      id: 0,
       xPx: 1.5,
       yPx: 1.5,
     },
@@ -72,7 +69,7 @@ rrr
 rwr
 rrr
 `, () => {
-  const plots = extractor.execute(3,3,[
+  const coords = extractor.execute(3,3,[
     255,0,0,0,
     0,0,0,0,
     0,0,0,0,
@@ -83,9 +80,8 @@ rrr
     0,0,0,0,
     255,0,0,0,
   ], [], false, [255,0,0], 10)
-  expect(plots).toEqual([
+  expect(coords).toEqual([
     {
-      id: 0,
       xPx: 1.5,
       yPx: 1.5,
     },
@@ -97,7 +93,7 @@ rrr
 www
 rrr
 `, () => {
-  const plots = extractor.execute(3,3,[
+  const coords = extractor.execute(3,3,[
     255,0,0,0,
     255,0,0,0,
     255,0,0,0,
@@ -108,14 +104,12 @@ rrr
     255,0,0,0,
     255,0,0,0,
   ], [], false, [255,0,0], 10)
-  expect(plots).toEqual([
+  expect(coords).toEqual([
     {
-      id: 0,
       xPx: 1.5,
       yPx: 0.5,
     },
     {
-      id: 1,
       xPx: 1.5,
       yPx: 2.5,
     },
@@ -127,7 +121,7 @@ rrr
 rrw
 rww
 `, () => {
-  const plots = extractor.execute(3,3,[
+  const coords = extractor.execute(3,3,[
     255,0,0,0,
     255,0,0,0,
     255,0,0,0,
@@ -138,9 +132,8 @@ rww
     0,0,0,0,
     0,0,0,0,
   ], [], false, [255,0,0], 10)
-  expect(plots).toEqual([
+  expect(coords).toEqual([
     {
-      id: 0,
       xPx: 1.2,
       yPx: 1.2,
     },
@@ -153,7 +146,7 @@ rrrr
 wwww
 rrrr
 `, () => {
-  const plots = extractor.execute(4,4,[
+  const coords = extractor.execute(4,4,[
     255,0,0,0,
     255,0,0,0,
     255,0,0,0,
@@ -171,14 +164,12 @@ rrrr
     255,0,0,0,
     255,0,0,0,
   ], [], false, [255,0,0], 10)
-  expect(plots).toEqual([
+  expect(coords).toEqual([
     {
-      id: 0,
       xPx: 2.0,
       yPx: 1,
     },
     {
-      id: 1,
       xPx: 2.0,
       yPx: 3.5,
     },

--- a/src/domains/extractStrategies/symbolExtractByArea.ts
+++ b/src/domains/extractStrategies/symbolExtractByArea.ts
@@ -1,6 +1,6 @@
 import ExtractStrategyInterface from './extractStrategyInterface'
 import { ExtractParent } from './extractParent'
-import { Plot } from '../datasetInterface'
+import { Coord } from '../datasetInterface'
 
 export default class SymbolExtractByArea
   extends ExtractParent
@@ -30,7 +30,7 @@ export default class SymbolExtractByArea
     targetColor: [number, number, number],
     colorMatchThreshold: number,
   ) {
-    const plots = []
+    const coords: Coord[] = []
     const visitedArea: boolean[][] = [...Array(height)].map(() =>
       Array(width).fill(false),
     )
@@ -74,9 +74,8 @@ export default class SymbolExtractByArea
         )
         visitedArea[h][w] = true
         if (isMatch) {
-          const pixels: Plot[] = [
+          const pixels: Coord[] = [
             {
-              id: 0,
               xPx: w,
               yPx: h,
             },
@@ -109,7 +108,6 @@ export default class SymbolExtractByArea
                   this.matchColor([r, g, b], targetColor, colorMatchThreshold)
                 ) {
                   pixels.push({
-                    id: pixels.length,
                     xPx: nw,
                     yPx: nh,
                   })
@@ -137,8 +135,7 @@ export default class SymbolExtractByArea
             // To avoid gaps between calculation and rendering
             // INFO: In manual, pixels are limited to moving one pixel at a time.
             const offsetPx = 0.5
-            plots.push({
-              id: plots.length,
+            coords.push({
               xPx: parseFloat((xPxTotal / pixels.length + offsetPx).toFixed(1)),
               yPx: parseFloat((yPxTotal / pixels.length + offsetPx).toFixed(1)),
             })
@@ -146,6 +143,6 @@ export default class SymbolExtractByArea
         }
       }
     }
-    return plots
+    return coords
   }
 }

--- a/src/domains/extractor.ts
+++ b/src/domains/extractor.ts
@@ -1,5 +1,5 @@
 import { CanvasInterface } from './canvasInterface'
-import { Plots } from './datasetInterface'
+import { Coord } from './datasetInterface'
 import ExtractStrategyInterface from './extractStrategies/extractStrategyInterface'
 
 //TODO 間藤さんに確認
@@ -17,7 +17,7 @@ export class Extractor {
     this.strategy = strategy
   }
 
-  execute(canvas: CanvasInterface): Plots {
+  execute(canvas: CanvasInterface): Coord[] {
     return this.strategy.execute(
       canvas.imageElement.height,
       canvas.imageElement.width,

--- a/src/domains/extractorInterface.ts
+++ b/src/domains/extractorInterface.ts
@@ -1,5 +1,5 @@
 import { CanvasInterface } from './canvasInterface'
-import { Plots } from './datasetInterface'
+import { Coord } from './datasetInterface'
 import ExtractStrategyInterface from './extractStrategies/extractStrategyInterface'
 
 export type ExtractStrategy = 'Symbol Extract' | 'Line Extract'
@@ -12,7 +12,7 @@ export interface ExtractorInterface {
   colorDistancePct: number
   swatches: string[][]
 
-  execute(canvas: CanvasInterface): Plots
+  execute(canvas: CanvasInterface): Coord[]
 
   get targetColor(): { R: number; G: number; B: number }
   get targetColorHex(): string

--- a/src/store/datasets.ts
+++ b/src/store/datasets.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { Datasets } from '@/domains/datasets'
 import { Dataset } from '@/domains/dataset'
-import { Plots, Coord } from '@/domains/datasetInterface'
+import { Coord } from '@/domains/datasetInterface'
 import { Vector } from '@/domains/axes/axesInterface'
 
 export interface State {
@@ -44,8 +44,8 @@ export const useDatasetsStore = defineStore('datasets', {
     clearActivePlots() {
       this.datasets.activeDataset.clearActivePlots()
     },
-    setPlots(plots: Plots) {
-      this.datasets.setPlots(plots)
+    setPlots(coords: Coord[]) {
+      this.datasets.setPlots(coords)
     },
     toggleActivatedPlot(id: number) {
       this.datasets.activeDataset.toggleActivatedPlot(id)


### PR DESCRIPTION
## 原因
- Auto Extract機能で抽出された点はPlotsとして直接dataset.plotsに代入されていたが、これだとaddPlot関数内で明示的にplotをvisibleな状態に登録する処理を通らず、invisibleと判定されて非表示のCSSが効いてしまっていた

## 対応
- Extractor内で扱っているPlot型のデータをすべてCoord型に変更
- Plotを直接代入する処理をやめ、上記Coordの配列を元にaddPlot関数を通るようにロジックを修正