### PR TITLE
fix: magnifierのplotカラーの設定をmain canvasと合わせる＆不使用propsの削除

### DIFF
--- a/src/components/Canvas/CanvasPlot.vue
+++ b/src/components/Canvas/CanvasPlot.vue
@@ -74,9 +74,6 @@ export default defineComponent({
     isVisible: {
       type: Boolean,
     },
-    isManuallyAdded: {
-      type: Boolean,
-    },
     isTemporary: {
       type: Boolean,
       default: false,

--- a/src/components/Canvas/CanvasPlots.vue
+++ b/src/components/Canvas/CanvasPlots.vue
@@ -7,9 +7,6 @@
       :plot="plot"
       :isActive="datasets.activeDataset.activePlotIds.includes(plot.id)"
       :isVisible="datasets.activeDataset.visiblePlotIds.includes(plot.id)"
-      :isManuallyAdded="
-        datasets.activeDataset.manuallyAddedPlotIds.includes(plot.id)
-      "
     ></canvas-plot>
     <canvas-plot
       v-for="(tempPlot, i) in datasets.activeDataset.scaledTempPlots(
@@ -20,7 +17,6 @@
       :plot="tempPlot"
       :isActive="false"
       :isVisible="true"
-      :isManuallyAdded="false"
       :isTemporary="true"
     ></canvas-plot>
   </div>

--- a/src/components/Magnifier/MagnifierMain.vue
+++ b/src/components/Magnifier/MagnifierMain.vue
@@ -18,9 +18,14 @@
           :plot="plot"
           :magnifierSize="magnifier.sizePx"
           :isActive="datasets.activeDataset.activePlotIds.includes(plot.id)"
-          :isManuallyAdded="
-            datasets.activeDataset.manuallyAddedPlotIds.includes(plot.id)
-          "
+        ></magnifier-plots>
+      </div>
+      <div v-for="plot in datasets.activeDataset.tempPlots" :key="plot.id">
+        <magnifier-plots
+          :plot="plot"
+          :magnifierSize="magnifier.sizePx"
+          :isActive="datasets.activeDataset.activePlotIds.includes(plot.id)"
+          :isTemporary="true"
         ></magnifier-plots>
       </div>
       <magnifier-extract-size></magnifier-extract-size>

--- a/src/components/Magnifier/MagnifierPlots.vue
+++ b/src/components/Magnifier/MagnifierPlots.vue
@@ -53,10 +53,10 @@ export default defineComponent({
       if (this.isActive) {
         return '#ff0000'
       }
-      if (this.isManuallyAdded) {
-        return '#1e90ff'
+      if (this.isTemporary) {
+        return '#999999'
       }
-      return '#7b68ee'
+      return '#1e90ff'
     },
   },
   props: {
@@ -71,8 +71,9 @@ export default defineComponent({
     isActive: {
       type: Boolean,
     },
-    isManuallyAdded: {
+    isTemporary: {
       type: Boolean,
+      default: false,
     },
   },
 })


### PR DESCRIPTION
- interpolation機能実装時にplotの色の条件分岐を実装したが、magnigierだけ古いものが残ってしまっていたので最新のものに合わせた
- 使われていないpropsが1個あったので削除