### PR TITLE
Refactor: interpolatorのプレビューロジックをservice層に移動

### DIFF
--- a/src/components/Settings/ExtractorSettings.vue
+++ b/src/components/Settings/ExtractorSettings.vue
@@ -66,7 +66,6 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue'
-import { Coord } from '@/domains/datasetInterface'
 
 import SymbolExtractSettings from './SymbolExtractSettings.vue'
 import LineExtractSettings from './LineExtractSettings.vue'
@@ -83,6 +82,7 @@ import { useAxesStore } from '@/store/axes'
 import { mapState, mapActions } from 'pinia'
 import { useInterpolatorStore } from '@/store/interpolator'
 import { useConfirmerStore } from '@/store/confirmer'
+import { previewInterpolation } from '@/services/interpolationPreviewer'
 
 export default defineComponent({
   components: {
@@ -159,40 +159,7 @@ export default defineComponent({
       }
     },
     handleOnClickInterpolate() {
-      const activeDataset = this.datasets.activeDataset
-
-      //INFO: Hide manually-added plots temporarilly, when previewing interpolation
-      activeDataset.manuallyAddedPlotIds.forEach((plotId) => {
-        activeDataset.removeVisiblePlotId(plotId)
-      })
-
-      this.interpolator.interpolatedCoords.forEach((coord: Coord) => {
-        activeDataset.addTempPlot(coord.xPx, coord.yPx)
-      })
-
-      setTimeout(() => {
-        this.confirmer.activate({
-          message: 'Do you want to apply these points?',
-          onConfirm: () => {
-            this.canvas.clearInterpolationGuideCanvas()
-
-            activeDataset.manuallyAddedPlotIds.forEach((plotId) => {
-              activeDataset.clearPlot(plotId)
-            })
-            activeDataset.tempPlots.forEach((tempPlot) => {
-              activeDataset.moveTempPlotToPlot(tempPlot.id)
-            })
-          },
-          onCancel: () => {
-            activeDataset.manuallyAddedPlotIds.forEach((plotId) => {
-              activeDataset.addVisiblePlotId(plotId)
-            })
-            activeDataset.tempPlots.forEach((tempPlot) => {
-              activeDataset.clearTempPlot(tempPlot.id)
-            })
-          },
-        })
-      }, 300)
+      previewInterpolation()
     },
     handleOnUpdateInterpolatorInterval(value: any) {
       const plots = this.datasets.activeDataset.manuallyAddedPlots

--- a/src/domains/canvasInterface.ts
+++ b/src/domains/canvasInterface.ts
@@ -4,4 +4,6 @@ export interface CanvasInterface {
   scale: number
   get originalSizeMaskCanvasColors(): Uint8ClampedArray
   get originalImageCanvasColors(): Uint8ClampedArray
+
+  clearInterpolationGuideCanvas(): void
 }

--- a/src/services/interpolationPreviewer.ts
+++ b/src/services/interpolationPreviewer.ts
@@ -1,0 +1,63 @@
+//TODO テストの追加
+
+import { Coord, DatasetInterface, Plot } from '@/domains/datasetInterface'
+import { useCanvasStore } from '@/store/canvas'
+import { useDatasetsStore } from '@/store/datasets'
+import { useInterpolatorStore } from '@/store/interpolator'
+import { useConfirmerStore } from '@/store/confirmer'
+import { CanvasInterface } from '@/domains/canvasInterface'
+
+const handleOnCancelInterpolation = (
+  canvas: CanvasInterface,
+  activeDataset: DatasetInterface,
+) => {
+  canvas.clearInterpolationGuideCanvas()
+
+  activeDataset.manuallyAddedPlotIds.forEach((plotId: number) => {
+    activeDataset.addVisiblePlotId(plotId)
+  })
+  activeDataset.tempPlots.forEach((tempPlot: Plot) => {
+    activeDataset.clearTempPlot(tempPlot.id)
+  })
+}
+
+const handleOnConfirmInterpolation = (activeDataset: DatasetInterface) => {
+  activeDataset.manuallyAddedPlotIds.forEach((plotId: number) => {
+    activeDataset.clearPlot(plotId)
+  })
+  activeDataset.tempPlots.forEach((tempPlot: Plot) => {
+    activeDataset.moveTempPlotToPlot(tempPlot.id)
+  })
+}
+
+const previewInterpolation = () => {
+  const { canvas } = useCanvasStore()
+  const { datasets } = useDatasetsStore()
+  const { interpolator } = useInterpolatorStore()
+  const { confirmer } = useConfirmerStore()
+
+  const activeDataset = datasets.activeDataset
+
+  activeDataset.manuallyAddedPlotIds.forEach((plotId) => {
+    activeDataset.removeVisiblePlotId(plotId)
+  })
+
+  interpolator.interpolatedCoords.forEach((coord: Coord) => {
+    activeDataset.addTempPlot(coord.xPx, coord.yPx)
+  })
+
+  //INFO 点群の描画を待ってから表示する
+  setTimeout(() => {
+    confirmer.activate({
+      message: 'Do you want to apply these points?',
+      onCancel: () => {
+        handleOnCancelInterpolation(canvas, activeDataset)
+      },
+      onConfirm: () => {
+        handleOnConfirmInterpolation(activeDataset)
+      },
+    })
+  }, 200)
+}
+
+export { previewInterpolation }


### PR DESCRIPTION
- interpolatorのプレビュー〜確定・キャンセルまで一連のフローに関するロジックのリファクタリング
- ExtractorSettingsコンポーネントから、servicesディレクトリに関数を切り出し

### TODO
テストの追加