### PR TITLE
Display app version only in production build

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,7 @@
         </v-btn>
         <v-col class="text-center text-white" cols="12">
           {{ new Date().getFullYear() }} — <strong>StarryDigitizer</strong
-          ><span class="ml-2 mt-1">{{ version }}</span>
+          ><span class="ml-2 mt-1">{{ isProd ? version : 'dev' }}</span>
         </v-col>
       </v-row>
     </v-footer>

--- a/src/components/StarryDigitizer.vue
+++ b/src/components/StarryDigitizer.vue
@@ -24,7 +24,7 @@
         ></extractor-settings>
         <p class="text-caption text-right">
           <!-- INFO: vバージョン#actionsのビルド番号 -->
-          v{{ version }}#{{ githubRunNumber }}
+          {{ appVerAndBuildInfo }}
         </p>
       </div>
     </div>
@@ -70,10 +70,21 @@ export default defineComponent({
       required: false,
     },
   },
+  computed: {
+    appVerAndBuildInfo() {
+      const appVer: string = this.isProd ? `v${this.version}` : ''
+      const buildNumber: string = this.githubRunNumber
+        ? `#${this.githubRunNumber}`
+        : ''
+
+      return appVer + buildNumber
+    },
+  },
   data() {
     return {
       version,
       githubRunNumber: import.meta.env.VITE_APP_GITHUB_RUN_NUMBER,
+      isProd: process.env.NODE_ENV === 'production',
     }
   },
 })


### PR DESCRIPTION
- Display app version only in production build
- ⚠️However, this change has an effect only on the local development build, since all the build types except local-development, is currently 'production' build. This matter will be discussed on  https://github.com/t29mato/starry-digitizer/issues/94