### PR TITLE
HACK: Since tempPlots are not drawn, force rendering as a temporary measure. Fundamental solution required

### DIFF
--- a/src/presentation/components/Settings/ExtractorSettings.vue
+++ b/src/presentation/components/Settings/ExtractorSettings.vue
@@ -98,6 +98,8 @@ import { CanvasHandler } from '@/application/services/canvasHandler/canvasHandle
 import { AxisRepositoryManager } from '@/domain/repositories/axisRepository/manager/axisRepositoryManager'
 import { DatasetRepositoryManager } from '@/domain/repositories/datasetRepository/manager/datasetRepositoryManager'
 
+import { forceRenderCanvasPlots } from '@/presentation/hacks/forceRenderCanvasPlots'
+
 export default defineComponent({
   components: {
     SymbolExtractSettings,
@@ -171,6 +173,9 @@ export default defineComponent({
         this.interpolator.clearPreview()
       }
 
+      //HACK: Since tempPlots are not drawn, force rendering as a temporary measure. Fundamental solution required
+      forceRenderCanvasPlots(this.datasets)
+
       addLocalStorageData('isInterpolatorActive', String(isActive))
     },
     handleOnConfirmInterpolation() {
@@ -196,6 +201,9 @@ export default defineComponent({
     handleOnUpdateInterpolatorInterval(value: any) {
       this.interpolator.updateInterval(parseFloat(value))
       this.interpolator.updatePreview()
+
+      //HACK: Since tempPlots are not drawn, force rendering as a temporary measure. Fundamental solution required
+      forceRenderCanvasPlots(this.datasets)
     },
   },
 })

--- a/src/presentation/hacks/forceRenderCanvasPlots.ts
+++ b/src/presentation/hacks/forceRenderCanvasPlots.ts
@@ -1,0 +1,9 @@
+import { DatasetRepositoryInterface } from '@/domain/repositories/datasetRepository/datasetRepositoryInterface'
+
+//🔥HACK!! A workaround for rare cases where canvas plots are not redrawn. Do not use unless it is absolutely unavoidable
+export const forceRenderCanvasPlots = (
+  datasets: DatasetRepositoryInterface,
+) => {
+  datasets.activeDataset.addPlot(9999, 9999)
+  datasets.activeDataset.clearPlot(datasets.activeDataset.lastPlotId)
+}


### PR DESCRIPTION
- Add hack function that create a dummy plot and remove it instantly.