### PR TITLE
Fix error on clicking '-' button of datasets panel

### DIFF
--- a/src/presentation/components/DatasetManager/DatasetManager.vue
+++ b/src/presentation/components/DatasetManager/DatasetManager.vue
@@ -7,7 +7,7 @@
       >
       <v-btn
         size="x-small"
-        @click="datasets.popDataset"
+        @click="handleOnClickPopDatasetButton"
         :disabled="datasets.datasets.length === 1"
         class="ml-2"
         ><v-icon>mdi-minus</v-icon></v-btn
@@ -90,6 +90,9 @@ export default defineComponent({
     },
     handleOnClickAddDatasetButton() {
       this.datasets.createNewDataset()
+    },
+    handleOnClickPopDatasetButton() {
+      this.datasets.popDataset()
     },
   },
 })


### PR DESCRIPTION
Since the 'popDataset' function was directly called in the component template, the reference of 'this' in the datasetRepository did not work properly.

Just moved the function call to the 'methods' of vue component