### PR TITLE
Improve magnifier visibility

### DIFF
--- a/src/application/services/magnifier/magnifier.ts
+++ b/src/application/services/magnifier/magnifier.ts
@@ -4,7 +4,7 @@ export class Magnifier implements MagnifierInterface {
   scale = 5
   magnifierSettingError = ''
   crosshairSizePx = 1
-  sizePx = 200
+  sizePx = 300
 
   private static instance: MagnifierInterface
 

--- a/src/presentation/components/Magnifier/MagnifierExtractSize.vue
+++ b/src/presentation/components/Magnifier/MagnifierExtractSize.vue
@@ -11,6 +11,7 @@
         width: `${lineExtract.dxPx * magnifier.scale}px`,
         height: `${lineExtract.dxPx * magnifier.scale}px`,
         border: '1px dotted grey',
+        zIndex: 5,
       }"
     ></div>
     <div v-if="extractor.strategy.name === 'Symbol Extract'">
@@ -22,6 +23,7 @@
           width: `${symbolMinDiameter}px`,
           height: `${symbolMinDiameter}px`,
           border: '1px dotted grey',
+          zIndex: 5,
         }"
       ></div>
       <div
@@ -32,6 +34,7 @@
           width: `${symbolMaxDiameter}px`,
           height: `${symbolMaxDiameter}px`,
           border: '1px dotted grey',
+          zIndex: 5,
         }"
       ></div>
     </div>

--- a/src/presentation/components/Magnifier/MagnifierMain.vue
+++ b/src/presentation/components/Magnifier/MagnifierMain.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="mb-5">
+  <div class="c__magnifier mb-5">
     <div
       :style="{
         overflow: 'hidden',
@@ -49,6 +49,12 @@
       <magnifier-axes></magnifier-axes>
       <magnifier-vertical-line></magnifier-vertical-line>
       <magnifier-horizontal-line></magnifier-horizontal-line>
+      <div class="c__magnifier__white-outlines">
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
     </div>
     <span>x: {{ xyValue.xV }}, y: {{ xyValue.yV }}</span>
     <magnifier-settings
@@ -146,3 +152,47 @@ export default defineComponent({
   },
 })
 </script>
+
+<style scoped lang="scss">
+$_white-outline-size: 24px;
+$_white-outline-pos-value: calc(50% - #{$_white-outline-size} - 1px);
+.c__magnifier {
+  &__white-outlines {
+    pointer-events: none;
+
+    & > div {
+      position: absolute;
+      width: $_white-outline-size;
+      height: $_white-outline-size;
+      border-color: white;
+      border-style: solid;
+      border-width: 0;
+      z-index: 3;
+
+      &:nth-child(1) {
+        top: $_white-outline-pos-value;
+        left: $_white-outline-pos-value;
+        border-width: 0 1px 1px 0;
+      }
+
+      &:nth-child(2) {
+        top: $_white-outline-pos-value;
+        right: $_white-outline-pos-value;
+        border-width: 0 0 1px 1px;
+      }
+
+      &:nth-child(3) {
+        bottom: $_white-outline-pos-value;
+        left: $_white-outline-pos-value;
+        border-width: 1px 1px 0 0;
+      }
+
+      &:nth-child(4) {
+        bottom: $_white-outline-pos-value;
+        right: $_white-outline-pos-value;
+        border-width: 1px 0 0 1px;
+      }
+    }
+  }
+}
+</style>


### PR DESCRIPTION
- Increase magnifier size
- Add white outline on the center of the magnifier, so that users can see the center guide even in the black background.

<img width="321" alt="スクリーンショット 2024-02-09 18 25 29" src="https://github.com/t29mato/starry-digitizer/assets/32313470/2eacb387-135f-44dc-9a8b-3ed41051e563">

<img width="327" alt="スクリーンショット 2024-02-09 18 25 54" src="https://github.com/t29mato/starry-digitizer/assets/32313470/e13bfe06-e9cc-446f-9420-9a711217fd72">
