### PR TITLE
ci: show preview url on slack notification

### DIFF
--- a/.github/workflows/vercel-preview-development.yaml
+++ b/.github/workflows/vercel-preview-development.yaml
@@ -42,9 +42,14 @@ jobs:
       - name: Build Project Artifacts
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+        run: |
+          DEPLOY_URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          echo "DEPLOY_URL=$DEPLOY_URL" >> $GITHUB_ENV
       - name: Notify Slack
         uses: rtCamp/action-slack-notify@v2.1.0
         env:
           SLACK_WEBHOOK: ${{ secrets.DIGITIZER_DEV_SLACK_WEBHOOK }}
           SLACK_COLOR: ${{ job.status }}
+          SLACK_MESSAGE: |
+            Preview URL: ${{ env.DEPLOY_URL }}
+


### PR DESCRIPTION
Since March 22, 2024, it has stopped receiving Slack notifications from Vercel. I have switched to sending Slack notifications from GitHub instead of Vercel.