### PR TITLE
Refactor datasetRepository and axisSetRepository constructors

### DIFF
--- a/src/domain/repositories/axisSetRepository/axisSetRepository.ts
+++ b/src/domain/repositories/axisSetRepository/axisSetRepository.ts
@@ -7,8 +7,18 @@ export class AxisSetRepository implements AxisSetRepositoryInterface {
   axisSets: AxisSetInterface[]
   activeAxisSetId = 1
 
-  constructor(axisSet: AxisSetInterface) {
-    this.axisSets = [axisSet]
+  constructor() {
+    this.axisSets = [
+      new AxisSet(
+        new Axis('x1', 0),
+        new Axis('x2', 1),
+        new Axis('y1', 0),
+        new Axis('y2', 1),
+        new Axis('x2y2', -1),
+        1,
+        'XY Axes 1',
+      ),
+    ]
   }
 
   get activeAxisSet(): AxisSetInterface {

--- a/src/domain/repositories/axisSetRepository/manager/axisSetRepositoryManager.ts
+++ b/src/domain/repositories/axisSetRepository/manager/axisSetRepositoryManager.ts
@@ -1,4 +1,3 @@
-import { Axis } from '@/domain/models/axis/axis'
 import { AxisSetRepository } from '../axisSetRepository'
 import { AxisSetRepositoryInterface } from '../axisSetRepositoryInterface'
 import { InstanceManager } from '@/general/instanceManager/instanceManager'
@@ -10,17 +9,7 @@ export class AxisSetRepositoryManager
   implements RepositoryManagerInterface<AxisSetRepositoryInterface>
 {
   private instanceCreator = () => {
-    return new AxisSetRepository(
-      new AxisSet(
-        new Axis('x1', 0),
-        new Axis('x2', 1),
-        new Axis('y1', 0),
-        new Axis('y2', 1),
-        new Axis('x2y2', -1),
-        1,
-        'XY Axes 1',
-      ),
-    )
+    return new AxisSetRepository()
   }
 
   public getInstance() {

--- a/src/domain/repositories/axisSetRepository/manager/axisSetRepositoryManager.ts
+++ b/src/domain/repositories/axisSetRepository/manager/axisSetRepositoryManager.ts
@@ -2,7 +2,6 @@ import { AxisSetRepository } from '../axisSetRepository'
 import { AxisSetRepositoryInterface } from '../axisSetRepositoryInterface'
 import { InstanceManager } from '@/general/instanceManager/instanceManager'
 import { RepositoryManagerInterface } from '../../repositoryManagerInterface'
-import { AxisSet } from '@/domain/models/axisSet/axisSet'
 
 export class AxisSetRepositoryManager
   extends InstanceManager<AxisSetRepositoryInterface>

--- a/src/domain/repositories/datasetRepository/datasetRepository.test.ts
+++ b/src/domain/repositories/datasetRepository/datasetRepository.test.ts
@@ -3,19 +3,19 @@ import { Dataset } from '../../models/dataset/dataset'
 import { DatasetRepository } from './datasetRepository'
 
 test('next dataset ID', () => {
-  const datasets = new DatasetRepository(new Dataset('dataset 1', [], 1))
+  const datasets = new DatasetRepository()
   expect(datasets.nextDatasetId).toBe(2)
 })
 
 test('add a dataset', () => {
-  const datasets = new DatasetRepository(new Dataset('dataset 1', [], 1))
+  const datasets = new DatasetRepository()
   datasets.addDataset(new Dataset('dataset 2', [], datasets.nextDatasetId))
   expect(datasets.datasets[0].id).toBe(1)
   expect(datasets.datasets[1].id).toBe(2)
 })
 
 test('remove a dataset', () => {
-  const datasets = new DatasetRepository(new Dataset('dataset 1', [], 1))
+  const datasets = new DatasetRepository()
   datasets.addDataset(new Dataset('dataset 2', [], datasets.nextDatasetId))
   datasets.addDataset(new Dataset('dataset 3', [], datasets.nextDatasetId))
 
@@ -24,7 +24,7 @@ test('remove a dataset', () => {
 })
 
 test('set points', () => {
-  const datasets = new DatasetRepository(new Dataset('dataset 1', [], 1))
+  const datasets = new DatasetRepository()
   datasets.addDataset(new Dataset('dataset 2', [], datasets.nextDatasetId))
   datasets.setPoints([{ xPx: 1, yPx: 1 }])
   expect(datasets.activeDataset.points).toStrictEqual([

--- a/src/domain/repositories/datasetRepository/datasetRepository.ts
+++ b/src/domain/repositories/datasetRepository/datasetRepository.ts
@@ -1,12 +1,13 @@
 import { Dataset } from '@/domain/models/dataset/dataset'
 import { DatasetInterface, Coord } from '../../models/dataset/datasetInterface'
+import { DatasetRepositoryInterface } from './datasetRepositoryInterface'
 
-export class DatasetRepository {
+export class DatasetRepository implements DatasetRepositoryInterface {
   datasets: DatasetInterface[]
   activeDatasetId = 1
 
-  constructor(dataset: DatasetInterface) {
-    this.datasets = [dataset]
+  constructor() {
+    this.datasets = [new Dataset('dataset 1', [], 1)]
   }
 
   get activeDataset(): DatasetInterface {

--- a/src/domain/repositories/datasetRepository/datasetRepositoryInterface.ts
+++ b/src/domain/repositories/datasetRepository/datasetRepositoryInterface.ts
@@ -1,4 +1,3 @@
-import { Dataset } from '@/domain/models/dataset/dataset'
 import { DatasetInterface } from '@/domain/models/dataset/datasetInterface'
 import { Coord } from '@/domain/models/dataset/datasetInterface'
 
@@ -10,7 +9,7 @@ export interface DatasetRepositoryInterface {
   get nextPointId(): number
   get nextDatasetId(): number
   get lastDatasetId(): number
-  get lastDataset(): Dataset
+  get lastDataset(): DatasetInterface
 
   setPoints(coords: Coord[]): void
   sortPoints(): void

--- a/src/domain/repositories/datasetRepository/manager/datasetRepositoryManager.ts
+++ b/src/domain/repositories/datasetRepository/manager/datasetRepositoryManager.ts
@@ -1,14 +1,14 @@
-import { Dataset } from '@/domain/models/dataset/dataset'
 import { DatasetRepository } from '@/domain/repositories/datasetRepository/datasetRepository'
 import { InstanceManager } from '@/general/instanceManager/instanceManager'
 import { RepositoryManagerInterface } from '../../repositoryManagerInterface'
+import { DatasetRepositoryInterface } from '../datasetRepositoryInterface'
 
 export class DatasetRepositoryManager
-  extends InstanceManager<DatasetRepository>
-  implements RepositoryManagerInterface<DatasetRepository>
+  extends InstanceManager<DatasetRepositoryInterface>
+  implements RepositoryManagerInterface<DatasetRepositoryInterface>
 {
   private instanceCreator = () => {
-    return new DatasetRepository(new Dataset('dataset 1', [], 1))
+    return new DatasetRepository()
   }
 
   public getInstance() {


### PR DESCRIPTION
Refactor the constructors of the datasetRepository and axisSetRepository classes to remove the dependency on the initial dataset or axis set. Instead, initialize the repositories with an empty array or a default axis set.

## Class diagram change

<img width="1356" alt="image" src="https://github.com/user-attachments/assets/2c2667e2-024b-45a5-83ba-66769fcf1c01">
