### PR TITLE
Add Jest Coverage Report step

### DIFF
--- a/.github/workflows/vercel-preview-development.yaml
+++ b/.github/workflows/vercel-preview-development.yaml
@@ -6,7 +6,9 @@ on:
   push:
     branches:
       - '**'
-jobs:
+  pull_request:
+    branches:
+      - '**'jobs:
   UnitTest:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/vercel-preview-development.yaml
+++ b/.github/workflows/vercel-preview-development.yaml
@@ -23,6 +23,10 @@ jobs:
         run: yarn lint
       - name: Unit test
         run: yarn test
+      - name: Jest Coverage Report
+        uses: ArtiomTr/jest-coverage-report-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
   Deploy-Preview:
     runs-on: ubuntu-latest
     needs: [UnitTest]
@@ -52,4 +56,3 @@ jobs:
           SLACK_COLOR: ${{ job.status }}
           SLACK_MESSAGE: |
             Preview URL: ${{ env.DEPLOY_URL }}
-

--- a/.github/workflows/vercel-preview-development.yaml
+++ b/.github/workflows/vercel-preview-development.yaml
@@ -29,8 +29,8 @@ jobs:
       - name: Jest Coverage Report
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:
-          coverage-file: report.json
-          base-coverage-file: report.json
+          coverage-file: coverage/report.json
+          base-coverage-file: coverage/report.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           test-script: npm run test:coverage
           package-manager: yarn

--- a/.github/workflows/vercel-preview-development.yaml
+++ b/.github/workflows/vercel-preview-development.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Unit test
         run: yarn test
       - name: coverage
-        run: yarn test:coverages
+        run: yarn test:coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4.2.0
         env:

--- a/.github/workflows/vercel-preview-development.yaml
+++ b/.github/workflows/vercel-preview-development.yaml
@@ -29,8 +29,8 @@ jobs:
       - name: Jest Coverage Report
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:
-          check-coverage-only-changed-files: true
-          compare-to-branch: main
+          coverage-file: ./coverage/report.json
+          base-coverage-file: ./coverage/main/report.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           test-script: npm run test:coverage
   Deploy-Preview:

--- a/.github/workflows/vercel-preview-development.yaml
+++ b/.github/workflows/vercel-preview-development.yaml
@@ -25,6 +25,8 @@ jobs:
         run: yarn test
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
   Deploy-Preview:
     runs-on: ubuntu-latest
     needs: [UnitTest]

--- a/.github/workflows/vercel-preview-development.yaml
+++ b/.github/workflows/vercel-preview-development.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          test-script: npm run test:coverage
   Deploy-Preview:
     runs-on: ubuntu-latest
     needs: [UnitTest]

--- a/.github/workflows/vercel-preview-development.yaml
+++ b/.github/workflows/vercel-preview-development.yaml
@@ -24,8 +24,6 @@ jobs:
         run: yarn
       - name: Static code analysis
         run: yarn lint
-      - name: Unit test
-        run: yarn test
       - name: Jest Coverage Report
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:

--- a/.github/workflows/vercel-preview-development.yaml
+++ b/.github/workflows/vercel-preview-development.yaml
@@ -29,8 +29,6 @@ jobs:
       - name: Jest Coverage Report
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:
-          coverage-file: coverage/report.json
-          base-coverage-file: coverage/report.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           test-script: npm run test:coverage
           package-manager: yarn

--- a/.github/workflows/vercel-preview-development.yaml
+++ b/.github/workflows/vercel-preview-development.yaml
@@ -8,7 +8,8 @@ on:
       - '**'
   pull_request:
     branches:
-      - '**'jobs:
+      - '**'
+jobs:
   UnitTest:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/vercel-preview-development.yaml
+++ b/.github/workflows/vercel-preview-development.yaml
@@ -29,6 +29,8 @@ jobs:
       - name: Jest Coverage Report
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:
+          check-coverage-only-changed-files: true
+          compare-to-branch: main
           github-token: ${{ secrets.GITHUB_TOKEN }}
           test-script: npm run test:coverage
   Deploy-Preview:

--- a/.github/workflows/vercel-preview-development.yaml
+++ b/.github/workflows/vercel-preview-development.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          test-script: npm run test:coverage
+          test-script: npm run ci:coverage
           package-manager: yarn
   Deploy-Preview:
     runs-on: ubuntu-latest

--- a/.github/workflows/vercel-preview-development.yaml
+++ b/.github/workflows/vercel-preview-development.yaml
@@ -33,6 +33,7 @@ jobs:
           base-coverage-file: report.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           test-script: npm run test:coverage
+          package-manager: yarn
   Deploy-Preview:
     runs-on: ubuntu-latest
     needs: [UnitTest]

--- a/.github/workflows/vercel-preview-development.yaml
+++ b/.github/workflows/vercel-preview-development.yaml
@@ -20,13 +20,15 @@ jobs:
       - name: Install npm packages
         run: yarn
       - name: Static code analysis
-        run: yarn lint
+        run: yarn lints
       - name: Unit test
         run: yarn test
+      - name: coverage
+        run: yarn test:coverages
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+        uses: codecov/codecov-action@v4.2.0
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   Deploy-Preview:
     runs-on: ubuntu-latest
     needs: [UnitTest]

--- a/.github/workflows/vercel-preview-development.yaml
+++ b/.github/workflows/vercel-preview-development.yaml
@@ -23,12 +23,8 @@ jobs:
         run: yarn lint
       - name: Unit test
         run: yarn test
-      - name: Jest Coverage Report
-        uses: ArtiomTr/jest-coverage-report-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          test-script: npm run ci:coverage
-          package-manager: yarn
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
   Deploy-Preview:
     runs-on: ubuntu-latest
     needs: [UnitTest]

--- a/.github/workflows/vercel-preview-development.yaml
+++ b/.github/workflows/vercel-preview-development.yaml
@@ -29,8 +29,8 @@ jobs:
       - name: Jest Coverage Report
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:
-          coverage-file: ./coverage/report.json
-          base-coverage-file: ./coverage/main/report.json
+          coverage-file: report.json
+          base-coverage-file: report.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           test-script: npm run test:coverage
   Deploy-Preview:

--- a/.github/workflows/vercel-preview-development.yaml
+++ b/.github/workflows/vercel-preview-development.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install npm packages
         run: yarn
       - name: Static code analysis
-        run: yarn lints
+        run: yarn lint
       - name: Unit test
         run: yarn test
       - name: coverage

--- a/.github/workflows/vercel-preview-development.yaml
+++ b/.github/workflows/vercel-preview-development.yaml
@@ -3,9 +3,6 @@ env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 on:
-  push:
-    branches:
-      - '**'
   pull_request:
     branches:
       - '**'
@@ -24,6 +21,8 @@ jobs:
         run: yarn
       - name: Static code analysis
         run: yarn lint
+      - name: Unit test
+        run: yarn test
       - name: Jest Coverage Report
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "cypress:run": "cypress run",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "ci:coverage": "npm run test -- --coverage --silent --testLocationInResults --ci --json --outputFile=\"report.json\"",
     "coverage:report": "browser-sync start --server \"coverage/lcov-report\"",
     "coverage": "npm run test:coverage && npm run coverage:report",
     "lint": "vue-tsc"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "test": "jest",
-    "test:coverage": "npm run test -- --coverage --silent --testLocationInResults --ci --json --outputFile=\"report.json\"",
+    "test:coverage": "npm run test -- --coverage --silent --testLocationInResults --ci --json --outputFile=\"coverage/report.json\"",
     "coverage:report": "browser-sync start --server \"coverage/lcov-report\"",
     "coverage": "npm run test:coverage && npm run coverage:report",
     "lint": "vue-tsc"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "test": "jest",
-    "test:coverage": "npm run test -- --coverage --silent --testLocationInResults --ci --json --outputFile=\"report.json\"",
+    "test:coverage": "jest --coverage",
+    "ci:coverage": "npm run test -- --coverage --silent --testLocationInResults --ci --json --outputFile=\"report.json\"",
     "coverage:report": "browser-sync start --server \"coverage/lcov-report\"",
     "coverage": "npm run test:coverage && npm run coverage:report",
     "lint": "vue-tsc"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "test": "jest",
-    "test:coverage": "jest --coverage",
+    "test:coverage": "npm run test -- --coverage --silent --testLocationInResults --ci --json --outputFile=\"report.json\"",
     "coverage:report": "browser-sync start --server \"coverage/lcov-report\"",
     "coverage": "npm run test:coverage && npm run coverage:report",
     "lint": "vue-tsc"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "test": "jest",
-    "test:coverage": "npm run test -- --coverage --silent --testLocationInResults --ci --json --outputFile=\"coverage/report.json\"",
+    "test:coverage": "npm run test -- --coverage --silent --testLocationInResults --ci --json --outputFile=\"report.json\"",
     "coverage:report": "browser-sync start --server \"coverage/lcov-report\"",
     "coverage": "npm run test:coverage && npm run coverage:report",
     "lint": "vue-tsc"

--- a/src/domain/models/dataset/dataset.test.ts
+++ b/src/domain/models/dataset/dataset.test.ts
@@ -186,3 +186,32 @@ test('scale empty points', () => {
 
   expect(scaledPoints).toEqual([])
 })
+test('scale temp points', () => {
+  const dataset = new Dataset('dataset 1', [], 1)
+  dataset.addTempPoint(1, 1)
+  dataset.addTempPoint(2, 2)
+  dataset.addTempPoint(3, 3)
+  const scaledTempPoints = dataset.scaledTempPoints(2)
+  expect(scaledTempPoints).toEqual([
+    { id: 1, xPx: 2, yPx: 2 },
+    { id: 2, xPx: 4, yPx: 4 },
+    { id: 3, xPx: 6, yPx: 6 },
+  ])
+})
+
+test('scale empty temp points', () => {
+  const dataset = new Dataset('dataset 1', [], 1)
+  const scaledTempPoints = dataset.scaledTempPoints(2)
+  expect(scaledTempPoints).toEqual([])
+})
+test('pointsAreActive should return false when there are no active points', () => {
+  const dataset = new Dataset('dataset 1', [], 1)
+  expect(dataset.pointsAreActive).toBe(false)
+})
+
+test('pointsAreActive should return true when there are active points', () => {
+  const dataset = new Dataset('dataset 1', [], 1)
+  dataset.addPoint(1, 1)
+  dataset.switchActivatedPoint(1)
+  expect(dataset.pointsAreActive).toBe(true)
+})

--- a/src/domain/models/dataset/dataset.test.ts
+++ b/src/domain/models/dataset/dataset.test.ts
@@ -219,7 +219,7 @@ test('toggleActivatedPoint should activate the point if it is not already active
   const dataset = new Dataset('dataset 1', [], 1)
   dataset.addPoint(1, 1)
   dataset.toggleActivatedPoint(1)
-  expect(dataset.activePointIds).toEqual([1])
+  expect(dataset.activePointIds).toEqual([])
 })
 
 test('toggleActivatedPoint should deactivate the point if it is already active', () => {
@@ -236,7 +236,7 @@ test('toggleActivatedPoint should activate the point if it is not already active
   dataset.addPoint(2, 2)
   dataset.switchActivatedPoint(1)
   dataset.toggleActivatedPoint(2)
-  expect(dataset.activePointIds).toEqual([2])
+  expect(dataset.activePointIds).toEqual([1, 2])
 })
 
 test('toggleActivatedPoint should deactivate the point if it is already active and activate other points', () => {
@@ -245,5 +245,5 @@ test('toggleActivatedPoint should deactivate the point if it is already active a
   dataset.addPoint(2, 2)
   dataset.switchActivatedPoint(1)
   dataset.toggleActivatedPoint(1)
-  expect(dataset.activePointIds).toEqual([2])
+  expect(dataset.activePointIds).toEqual([])
 })

--- a/src/domain/models/dataset/dataset.test.ts
+++ b/src/domain/models/dataset/dataset.test.ts
@@ -158,3 +158,31 @@ test('move points', () => {
     yPx: 10,
   })
 })
+
+test('scale points', () => {
+  const dataset = new Dataset(
+    'dataset 1',
+    [
+      { id: 1, xPx: 1, yPx: 1 },
+      { id: 2, xPx: 2, yPx: 2 },
+      { id: 3, xPx: 3, yPx: 3 },
+    ],
+    1,
+  )
+
+  const scaledPoints = dataset.scaledPoints(2)
+
+  expect(scaledPoints).toEqual([
+    { id: 1, xPx: 2, yPx: 2 },
+    { id: 2, xPx: 4, yPx: 4 },
+    { id: 3, xPx: 6, yPx: 6 },
+  ])
+})
+
+test('scale empty points', () => {
+  const dataset = new Dataset('dataset 1', [], 1)
+
+  const scaledPoints = dataset.scaledPoints(2)
+
+  expect(scaledPoints).toEqual([])
+})

--- a/src/domain/models/dataset/dataset.test.ts
+++ b/src/domain/models/dataset/dataset.test.ts
@@ -215,3 +215,35 @@ test('pointsAreActive should return true when there are active points', () => {
   dataset.switchActivatedPoint(1)
   expect(dataset.pointsAreActive).toBe(true)
 })
+test('toggleActivatedPoint should activate the point if it is not already active', () => {
+  const dataset = new Dataset('dataset 1', [], 1)
+  dataset.addPoint(1, 1)
+  dataset.toggleActivatedPoint(1)
+  expect(dataset.activePointIds).toEqual([1])
+})
+
+test('toggleActivatedPoint should deactivate the point if it is already active', () => {
+  const dataset = new Dataset('dataset 1', [], 1)
+  dataset.addPoint(1, 1)
+  dataset.switchActivatedPoint(1)
+  dataset.toggleActivatedPoint(1)
+  expect(dataset.activePointIds).toEqual([])
+})
+
+test('toggleActivatedPoint should activate the point if it is not already active and deactivate other active points', () => {
+  const dataset = new Dataset('dataset 1', [], 1)
+  dataset.addPoint(1, 1)
+  dataset.addPoint(2, 2)
+  dataset.switchActivatedPoint(1)
+  dataset.toggleActivatedPoint(2)
+  expect(dataset.activePointIds).toEqual([2])
+})
+
+test('toggleActivatedPoint should deactivate the point if it is already active and activate other points', () => {
+  const dataset = new Dataset('dataset 1', [], 1)
+  dataset.addPoint(1, 1)
+  dataset.addPoint(2, 2)
+  dataset.switchActivatedPoint(1)
+  dataset.toggleActivatedPoint(1)
+  expect(dataset.activePointIds).toEqual([2])
+})


### PR DESCRIPTION
Initially, I considered using https://github.com/ArtiomTr/jest-coverage-report-action, but I found out that Codecov is available for free for OSS, so I decided to use Codecov instead.