### PR TITLE
added some test code to dataset domain model

### DIFF
--- a/src/domain/models/dataset/dataset.test.ts
+++ b/src/domain/models/dataset/dataset.test.ts
@@ -158,3 +158,91 @@ test('move points', () => {
     yPx: 10,
   })
 })
+test('scale points', () => {
+  const dataset = new Dataset(
+    'dataset 1',
+    [
+      { id: 1, xPx: 1, yPx: 1 },
+      { id: 2, xPx: 2, yPx: 2 },
+      { id: 3, xPx: 3, yPx: 3 },
+    ],
+    1,
+  )
+
+  const scaledPoints = dataset.scaledPoints(2)
+
+  expect(scaledPoints).toEqual([
+    { id: 1, xPx: 2, yPx: 2 },
+    { id: 2, xPx: 4, yPx: 4 },
+    { id: 3, xPx: 6, yPx: 6 },
+  ])
+})
+
+test('scale empty points', () => {
+  const dataset = new Dataset('dataset 1', [], 1)
+
+  const scaledPoints = dataset.scaledPoints(2)
+
+  expect(scaledPoints).toEqual([])
+})
+test('scale temp points', () => {
+  const dataset = new Dataset('dataset 1', [], 1)
+  dataset.addTempPoint(1, 1)
+  dataset.addTempPoint(2, 2)
+  dataset.addTempPoint(3, 3)
+  const scaledTempPoints = dataset.scaledTempPoints(2)
+  expect(scaledTempPoints).toEqual([
+    { id: 1, xPx: 2, yPx: 2 },
+    { id: 2, xPx: 4, yPx: 4 },
+    { id: 3, xPx: 6, yPx: 6 },
+  ])
+})
+
+test('scale empty temp points', () => {
+  const dataset = new Dataset('dataset 1', [], 1)
+  const scaledTempPoints = dataset.scaledTempPoints(2)
+  expect(scaledTempPoints).toEqual([])
+})
+test('pointsAreActive should return false when there are no active points', () => {
+  const dataset = new Dataset('dataset 1', [], 1)
+  expect(dataset.pointsAreActive).toBe(false)
+})
+
+test('pointsAreActive should return true when there are active points', () => {
+  const dataset = new Dataset('dataset 1', [], 1)
+  dataset.addPoint(1, 1)
+  dataset.switchActivatedPoint(1)
+  expect(dataset.pointsAreActive).toBe(true)
+})
+test('toggleActivatedPoint should activate the point if it is not already active', () => {
+  const dataset = new Dataset('dataset 1', [], 1)
+  dataset.addPoint(1, 1)
+  dataset.toggleActivatedPoint(1)
+  expect(dataset.activePointIds).toEqual([])
+})
+
+test('toggleActivatedPoint should deactivate the point if it is already active', () => {
+  const dataset = new Dataset('dataset 1', [], 1)
+  dataset.addPoint(1, 1)
+  dataset.switchActivatedPoint(1)
+  dataset.toggleActivatedPoint(1)
+  expect(dataset.activePointIds).toEqual([])
+})
+
+test('toggleActivatedPoint should activate the point if it is not already active and deactivate other active points', () => {
+  const dataset = new Dataset('dataset 1', [], 1)
+  dataset.addPoint(1, 1)
+  dataset.addPoint(2, 2)
+  dataset.switchActivatedPoint(1)
+  dataset.toggleActivatedPoint(2)
+  expect(dataset.activePointIds).toEqual([1, 2])
+})
+
+test('toggleActivatedPoint should deactivate the point if it is already active and activate other points', () => {
+  const dataset = new Dataset('dataset 1', [], 1)
+  dataset.addPoint(1, 1)
+  dataset.addPoint(2, 2)
+  dataset.switchActivatedPoint(1)
+  dataset.toggleActivatedPoint(1)
+  expect(dataset.activePointIds).toEqual([])
+})


### PR DESCRIPTION
In PR https://github.com/t29mato/starry-digitizer/pull/207, Codecov has been integrated.

This is a sample PR to show Codecov's comment on GitHub PR.
Now, the test coverage will be displayed for PRs like this PR, along with the differences showing how much the PR improves test coverage.
<img width="607" alt="image" src="https://github.com/user-attachments/assets/e8901e50-ccad-4474-a6a9-9f74a8cadaa2">

Please check and merge if there are no issues.

